### PR TITLE
Edit history refresh triggers

### DIFF
--- a/modules/portfolio/lib/portfolio-data.service.ts
+++ b/modules/portfolio/lib/portfolio-data.service.ts
@@ -176,8 +176,6 @@ export class PortfolioDataService {
             console.log(`portfolio cache <${timestamp}>: saving beets bar`);
             await this.saveBeetsBar(blockNumber, beetsBar, beetsBarUsers);
 
-            console.log(`portfolio cache <${timestamp}>: saving latest block`);
-            await this.refreshLatestBlockCachedTimestamp();
             console.log(`portfolio cache <${timestamp}>: done`);
         } catch (e) {
             console.log(`error <${timestamp}>`, e);

--- a/modules/portfolio/portfolio.service.ts
+++ b/modules/portfolio/portfolio.service.ts
@@ -157,6 +157,7 @@ class PortfolioService {
 
         if (blocks.length > 0) {
             await this.dataService.cachePortfolioHistory(address, blocks[0].timestamp, portfolioHistories);
+            await this.dataService.refreshLatestBlockCachedTimestamp();
         }
 
         return portfolioHistories;


### PR DESCRIPTION
I'm not 100% sure I got this correctly but AFAIK:

- When a request asks for portfolio history it checks the redis cache, if it's not in there, it will create the history from the sql db and put it into the redis cache, but doesn't refresh refreshLatestBlockCachedTimestamp() which I think is wrong.
- On the other hand, the cron writes everything into the sql db and triggers the refreshLatestBlockCachedTimestamp() without putting anything into redis, which does not make sense.

TBH: not sure I got everything, but this might be why we have such strange behaviour.