### PR TITLE
dont print full stack trace

### DIFF
--- a/modules/util/multicaller.ts
+++ b/modules/util/multicaller.ts
@@ -31,8 +31,13 @@ export class Multicaller {
 
     async execute(from: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
         const obj = from;
-        const results = await this.executeMulticall();
-        results.forEach((result, i) => set(obj, this.paths[i], result.length > 1 ? result : result[0]));
+        // not print the full exception for now, not polluting the log too much
+        try {
+            const results = await this.executeMulticall();
+            results.forEach((result, i) => set(obj, this.paths[i], result.length > 1 ? result : result[0]));
+        } catch (err) {
+            throw `Non-stacktrace multicall error`
+        }
         this.calls = [];
         this.paths = [];
         return obj;


### PR DESCRIPTION
Log is very polluted and hard to debug. Stop logging the stacktrace of the multicall error