### PR TITLE
Fix zap portfolio

### DIFF
--- a/modules/portfolio/lib/portfolio-data.service.ts
+++ b/modules/portfolio/lib/portfolio-data.service.ts
@@ -92,10 +92,12 @@ export class PortfolioDataService {
         const blockNumber = parseInt(block.number);
         const poolShares = [];
 
-        const poolIds = [];
+        const poolIds: string[] = [];
+        const poolAddresses: string[] = [];
+
         for (const farm of farmUsers) {
             if (farm.pool) {
-                poolIds.push(farm.pool?.pair);
+                poolAddresses.push(farm.pool.pair);
             }
         }
         for (const sharesOwned of user.sharesOwned ?? []) {
@@ -103,8 +105,7 @@ export class PortfolioDataService {
         }
 
         for (const pool of pools) {
-            // pool.address for masterchef subgraph, pool.id for sharesOwned in balancer subgraph
-            if (poolIds.includes(pool.address) || poolIds.includes(pool.id)) {
+            if (poolAddresses.includes(pool.address) || poolIds.includes(pool.id)) {
                 const poolSnapshot: PrismaBalancerPoolSnapshotWithTokens = {
                     ...pool,
                     poolId: pool.id,

--- a/modules/portfolio/lib/portfolio-data.service.ts
+++ b/modules/portfolio/lib/portfolio-data.service.ts
@@ -106,7 +106,7 @@ export class PortfolioDataService {
             // pool.address for masterchef subgraph, pool.id for sharesOwned in balancer subgraph
             if (poolIds.includes(pool.address) || poolIds.includes(pool.id)) {
                 const poolSnapshot: PrismaBalancerPoolSnapshotWithTokens = {
-                    ...pools.find((pool) => pool.id === pool.id)!,
+                    ...pool,
                     poolId: pool.id,
                     amp: pool.amp ?? null,
                     blockNumber,
@@ -119,19 +119,19 @@ export class PortfolioDataService {
                     })),
                 };
 
-                const myDummySharesOwned = {
-                    balance: '0', // not used
-                    id: '0x00', // not used
+                const sharesOwned = {
+                    balance: '0', // not used. always 0
+                    id: `${pool.address}-${userAddress}`,
                     poolId: {
                         id: pool.id,
                     },
                 };
 
                 poolShares.push({
-                    ...myDummySharesOwned,
+                    ...sharesOwned,
                     userAddress,
                     blockNumber,
-                    poolId: myDummySharesOwned.poolId.id,
+                    poolId: sharesOwned.poolId.id,
                     poolSnapshotId: '',
                     poolSnapshot,
                 });


### PR DESCRIPTION
Need to also get the pools from the Masterchef because if I zap into a farm directly without ever joined the pool, I never owned the BPT and will not be part of the sharesOwned query in the balancer subgraph.

We will get the pool address and pool id from Masterchef subgraph and balancer subgraph respectively, loop through all pools and match with the pool id/address. Need to manually construct a sharesOwned type, especially needed for pool that are only in Masterchef .

fixes #2 

I assume there is a nicer typescript way to construct the pool-id/address array :) help!