### PR TITLE
Update last synced block when no balance changes occurred

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Trigger the following mutations when you start from a clean DB:
 
 ```
-userInitWalletBalancesForAllPools
-poolReloadStakingForAllPools
-userInitStakedBalances
 poolSyncAllPoolsFromSubgraph
+poolReloadStakingForAllPools
+userInitWalletBalancesForAllPools
+userInitStakedBalances
 ```

--- a/modules/user/lib/user-sync-wallet-balance.service.ts
+++ b/modules/user/lib/user-sync-wallet-balance.service.ts
@@ -130,6 +130,12 @@ export class UserSyncWalletBalanceService {
         );
 
         if (balancesToFetch.length === 0) {
+            await prisma.prismaUserBalanceSyncStatus.upsert({
+                where: { type: 'WALLET' },
+                create: { type: 'WALLET', blockNumber: toBlock },
+                update: { blockNumber: toBlock },
+            });
+
             return;
         }
 

--- a/worker/scheduleLocalWorkerTasks.ts
+++ b/worker/scheduleLocalWorkerTasks.ts
@@ -99,7 +99,7 @@ function addRpcListener(taskName: string, eventType: string, timeout: number, li
                         console.timeEnd(taskName);
                     });
             });
-        }, 5000),
+        }, 1),
     );
 }
 


### PR DESCRIPTION
If no balance changes occurred within the max block range, the function returns early without updating the latest synced block which is fixed by this PR