### PR TITLE
Improve query for pools without snapshots

### DIFF
--- a/modules/pool/lib/pool-snapshot.service.ts
+++ b/modules/pool/lib/pool-snapshot.service.ts
@@ -86,7 +86,7 @@ export class PoolSnapshotService {
         await prismaBulkExecuteOperations(operations, true);
 
         const poolsWithoutSnapshots = await prisma.prismaPool.findMany({
-            where: { id: { notIn: poolIds } },
+            where: { OR: [{ type: 'PHANTOM_STABLE' }, { tokens: { some: { nestedPoolId: { not: null } } } }] },
             include: { tokens: true },
         });
 
@@ -156,7 +156,7 @@ export class PoolSnapshotService {
                         token.address,
                         numDays,
                     );
-                    await sleep(8000);
+                    await sleep(5000);
                 } catch (error: any) {
                     // Sentry.captureException(error);
                     console.error(


### PR DESCRIPTION
resolves #95

Issue was that we have a lot of unused pools which generate no swaps and therefore have no snapshot on the subgraph. This resulted in the pools without snapshots to have over 1000 entries making the coingecko delayed requests stretching the job over a very long period