### PR TITLE
Fix missing token price from conigecko

### DIFF
--- a/modules/coingecko/coingecko.service.ts
+++ b/modules/coingecko/coingecko.service.ts
@@ -171,7 +171,6 @@ export class CoingeckoService {
                     console.warn(`Matching address for original address ${mappedToken.originalAddress} not found`);
                 } else {
                     prices[mappedToken.originalAddress] = results[resultAddress];
-                    delete prices[resultAddress];
                 }
             }
         }


### PR DESCRIPTION
Deleting the mapped address  leads to an issue if the mapped token is also requested in the price query on its own. For example usdc was a mapped token for solana's usdc version but also in there on its own. but by removing the mapped entry, it also removed the entry for ftm's version of usdc. This resulted in the native USDC price being calculated by the fallback swap price handler. which could also have resulted in the sometimes weird usdc prices