### PR TITLE
Load pools for swaps within a join

### DIFF
--- a/modules/pool/lib/pool-gql-loader.service.ts
+++ b/modules/pool/lib/pool-gql-loader.service.ts
@@ -59,14 +59,16 @@ export class PoolGqlLoaderService {
             include: prismaPoolMinimal.include,
         });
 
-        return pools.map((pool) => {
-            return {
-                ...pool,
-                decimals: 18,
-                dynamicData: this.getPoolDynamicData(pool),
-                allTokens: this.mapAllTokens(pool),
-            };
-        });
+        return pools.map(this.mapToMinimalGqlPool);
+    }
+
+    public mapToMinimalGqlPool(pool: PrismaPoolMinimal): GqlPoolMinimal {
+        return {
+            ...pool,
+            decimals: 18,
+            dynamicData: this.getPoolDynamicData(pool),
+            allTokens: this.mapAllTokens(pool),
+        };
     }
 
     public async getPoolsCount(args: QueryPoolGetPoolsArgs): Promise<number> {

--- a/modules/pool/lib/pool-swap.service.ts
+++ b/modules/pool/lib/pool-swap.service.ts
@@ -18,7 +18,7 @@ import {
 import { PrismaPoolSwap } from '@prisma/client';
 import _ from 'lodash';
 import { prismaBulkExecuteOperations } from '../../../prisma/prisma-util';
-import { PrismaPoolBatchSwapWithSwaps } from '../../../prisma/prisma-types';
+import { PrismaPoolBatchSwapWithSwaps, prismaPoolMinimal } from '../../../prisma/prisma-types';
 
 export class PoolSwapService {
     constructor(
@@ -143,7 +143,9 @@ export class PoolSwapService {
                 },
             },
             orderBy: { timestamp: 'desc' },
-            include: { swaps: true },
+            include: {
+                swaps: { include: { pool: { include: prismaPoolMinimal.include } } },
+            },
         });
     }
 

--- a/modules/pool/pool.service.ts
+++ b/modules/pool/pool.service.ts
@@ -89,21 +89,13 @@ export class PoolService {
 
     public async getPoolBatchSwaps(args: QueryPoolGetBatchSwapsArgs): Promise<GqlPoolBatchSwap[]> {
         const batchSwaps = await this.poolSwapService.getBatchSwaps(args);
-        const poolIds = batchSwaps.map((batchSwap) => batchSwap.swaps.map((swap) => swap.poolId)).flat();
-        const pools = await this.getGqlPools({ where: { idIn: poolIds } });
 
         return batchSwaps.map((batchSwap) => ({
             ...batchSwap,
             swaps: batchSwap.swaps.map((swap) => {
-                const pool = pools.find((pool) => pool.id === swap.poolId)!;
-                if (!pool) {
-                    console.log(
-                        `Missing pool for swap ${JSON.stringify(swap)} in batchSwap ${JSON.stringify(batchSwap)}`,
-                    );
-                }
                 return {
                     ...swap,
-                    pool,
+                    pool: this.poolGqlLoaderService.mapToMinimalGqlPool(swap.pool),
                 };
             }),
         }));

--- a/prisma/prisma-types.ts
+++ b/prisma/prisma-types.ts
@@ -203,7 +203,7 @@ export type PrismaPoolMinimal = Prisma.PrismaPoolGetPayload<typeof prismaPoolMin
 
 export const prismaPoolBatchSwapWithSwaps = Prisma.validator<Prisma.PrismaPoolBatchSwapArgs>()({
     include: {
-        swaps: true,
+        swaps: { include: { pool: { include: prismaPoolMinimal.include } } },
     },
 });
 


### PR DESCRIPTION
Fixes issues when swaps reference a pool which is filtered out by the minimum number of shares provided. resolves #42 