### PR TITLE
APR calc changes, datafeed adaption, new subgraphs, minor fixes

### DIFF
--- a/modules/common/time.ts
+++ b/modules/common/time.ts
@@ -106,7 +106,12 @@ export function getDailyTimestampsWithBuffer(numDays: number): number[] {
     while (current.isAfter(endTime)) {
         timestamps = [
             ...timestamps,
-            //we create a buffer of 3 seconds to match on to ensure we get at least one block for this hour
+            //we create a buffer of 20 seconds to match on to ensure we get at least one block for this hour
+            current.clone().subtract(10, 'second').unix(),
+            current.clone().subtract(9, 'second').unix(),
+            current.clone().subtract(8, 'second').unix(),
+            current.clone().subtract(7, 'second').unix(),
+            current.clone().subtract(6, 'second').unix(),
             current.clone().subtract(5, 'second').unix(),
             current.clone().subtract(4, 'second').unix(),
             current.clone().subtract(3, 'second').unix(),
@@ -118,6 +123,11 @@ export function getDailyTimestampsWithBuffer(numDays: number): number[] {
             current.clone().add(3, 'second').unix(),
             current.clone().add(4, 'second').unix(),
             current.clone().add(5, 'second').unix(),
+            current.clone().add(6, 'second').unix(),
+            current.clone().add(7, 'second').unix(),
+            current.clone().add(8, 'second').unix(),
+            current.clone().add(9, 'second').unix(),
+            current.clone().add(10, 'second').unix(),
         ];
 
         current = current.subtract(1, 'day');

--- a/modules/config/network-config.ts
+++ b/modules/config/network-config.ts
@@ -67,8 +67,9 @@ export interface NetworkConfig {
     copper: {
         proxyAddress: string;
     };
-    reaper?: {
+    reaper: {
         linearPoolFactories: string[];
+        averageAPRAcrossLastNHarvests: number;
     };
     yearn: {
         vaultsEndpoint: string;
@@ -192,6 +193,7 @@ const AllNetworkConfigs: { [chainId: string]: NetworkConfig } = {
         },
         reaper: {
             linearPoolFactories: ['0xd448c4156b8de31e56fdfc071c8d96459bb28119'],
+            averageAPRAcrossLastNHarvests: 5,
         },
         datastudio: {
             main: {
@@ -296,6 +298,7 @@ const AllNetworkConfigs: { [chainId: string]: NetworkConfig } = {
                 '0x19968d4b7126904fd665ed25417599df9604df83',
                 '0xe4b88e745dce9084b9fc2439f85a9a4c5cd6f361',
             ],
+            averageAPRAcrossLastNHarvests: 2,
         },
         lido: {
             wstEthAprEndpoint: 'https://stake.lido.fi/api/steth-apr',

--- a/modules/config/network-config.ts
+++ b/modules/config/network-config.ts
@@ -112,7 +112,7 @@ const AllNetworkConfigs: { [chainId: string]: NetworkConfig } = {
         },
         subgraphs: {
             startDate: '2021-10-08',
-            balancer: 'https://api.thegraph.com/subgraphs/name/beethovenxfi/beethovenx',
+            balancer: 'https://api.thegraph.com/subgraphs/name/beethovenxfi/beethovenx-v2-fantom',
             beetsBar: 'https://api.thegraph.com/subgraphs/name/beethovenxfi/beets-bar',
             blocks: 'https://api.thegraph.com/subgraphs/name/beethovenxfi/fantom-blocks',
             changelog: 'https://api.thegraph.com/subgraphs/name/beethovenxfi/changelog',

--- a/modules/config/network-config.ts
+++ b/modules/config/network-config.ts
@@ -221,7 +221,7 @@ const AllNetworkConfigs: { [chainId: string]: NetworkConfig } = {
         },
         subgraphs: {
             startDate: '2022-01-01',
-            balancer: 'https://api.thegraph.com/subgraphs/name/beethovenxfi/beethovenx-optimism',
+            balancer: 'https://api.thegraph.com/subgraphs/name/beethovenxfi/beethovenx-v2-optimism',
             beetsBar: 'https://',
             blocks: 'https://api.thegraph.com/subgraphs/name/danielmkm/optimism-blocks',
             changelog: 'https://api.thegraph.com/subgraphs/name/beethovenxfi/changelog-optimism',

--- a/modules/config/network-config.ts
+++ b/modules/config/network-config.ts
@@ -54,8 +54,8 @@ export interface NetworkConfig {
     };
     balancer: {
         vault: string;
-        weightedPoolV2Factory: string;
-        coposableStablePoolFactory: string;
+        weightedPoolV2Factories: string[];
+        composableStablePoolFactories: string[];
         yieldProtocolFeePercentage: number;
         swapProtocolFeePercentage: number;
     };
@@ -154,8 +154,14 @@ const AllNetworkConfigs: { [chainId: string]: NetworkConfig } = {
         },
         balancer: {
             vault: '0x20dd72Ed959b6147912C2e529F0a0C651c33c9ce',
-            coposableStablePoolFactory: '0xB384A86F2Fd7788720db42f9daa60fc07EcBeA06',
-            weightedPoolV2Factory: '0x8ea1c497c16726E097f62C8C9FBD944143F27090',
+            composableStablePoolFactories: [
+                '0xB384A86F2Fd7788720db42f9daa60fc07EcBeA06',
+                '0x44814E3A603bb7F1198617995c5696C232F6e8Ed',
+            ],
+            weightedPoolV2Factories: [
+                '0x8ea1c497c16726E097f62C8C9FBD944143F27090',
+                '0xea87F3dFfc679035653C0FBa70e7bfe46E3FB733',
+            ],
             swapProtocolFeePercentage: 0.25,
             yieldProtocolFeePercentage: 0.25,
         },
@@ -263,8 +269,8 @@ const AllNetworkConfigs: { [chainId: string]: NetworkConfig } = {
         },
         balancer: {
             vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
-            coposableStablePoolFactory: '0xf145caFB67081895EE80eB7c04A30Cf87f07b745',
-            weightedPoolV2Factory: '0xad901309d9e9DbC5Df19c84f729f429F0189a633',
+            composableStablePoolFactories: ['0xf145caFB67081895EE80eB7c04A30Cf87f07b745'],
+            weightedPoolV2Factories: ['0xad901309d9e9DbC5Df19c84f729f429F0189a633'],
             swapProtocolFeePercentage: 0.5,
             yieldProtocolFeePercentage: 0.5,
         },

--- a/modules/config/network-config.ts
+++ b/modules/config/network-config.ts
@@ -301,7 +301,7 @@ const AllNetworkConfigs: { [chainId: string]: NetworkConfig } = {
             averageAPRAcrossLastNHarvests: 2,
         },
         lido: {
-            wstEthAprEndpoint: 'https://stake.lido.fi/api/steth-apr',
+            wstEthAprEndpoint: 'https://eth-api.lido.fi/v1/protocol/steth/apr/sma',
             wstEthContract: '0x1f32b1c2345538c0c6f582fcb022739c4a194ebb',
         },
         overnight: {

--- a/modules/datastudio/datastudio.service.ts
+++ b/modules/datastudio/datastudio.service.ts
@@ -31,7 +31,7 @@ export class DatastudioService {
 
         const sheets = google.sheets({ version: 'v4' });
 
-        const range = `${this.databaseTabName}!B2:G`;
+        const range = `${this.databaseTabName}!B2:J`;
         let currentSheetValues;
         currentSheetValues = await sheets.spreadsheets.values.get({
             auth: jwtClient,
@@ -50,6 +50,8 @@ export class DatastudioService {
             // 24 hours did not pass since the last run
             return;
         }
+
+        const now = moment.tz('GMT').unix();
 
         const allPoolDataRows: string[][] = [];
         const allPoolCompositionRows: string[][] = [];
@@ -95,10 +97,10 @@ export class DatastudioService {
             let yesterdaySwapsCount = `0`;
             //find last entry of pool in currentSheet and get total swaps. If no previous value present, set previous value to 0
             if (currentSheetValues.data.values) {
-                // string[row][column], index 1 is address, index 5 total swap count
+                // string[row][column], index 2 is address, index 8 total swap count
                 currentSheetValues.data.values.forEach((row) => {
-                    if (pool.address === row[1] && endOfDayBeforeYesterday === row[0]) {
-                        yesterdaySwapsCount = row[5];
+                    if (pool.address === row[2] && endOfDayBeforeYesterday === row[0]) {
+                        yesterdaySwapsCount = row[8];
                     }
                 });
             }
@@ -129,26 +131,27 @@ export class DatastudioService {
             allPoolDataRows.push([
                 endOfYesterday.format('DD MMM YYYY'),
                 `${endOfYesterday.unix()}`,
+                `${now}`,
                 pool.address,
-                poolType,
                 pool.name,
-                swapFee,
-                pool.dynamicData?.swapsCount ? `${pool.dynamicData.swapsCount}` : `0`,
+                poolType,
                 pool.symbol,
+                swapFee,
                 pool.dynamicData?.totalLiquidity ? `${pool.dynamicData.totalLiquidity}` : `0`,
+                pool.dynamicData?.swapsCount ? `${pool.dynamicData.swapsCount}` : `0`,
                 pool.dynamicData?.totalShares ? `${pool.dynamicData.totalShares}` : `0`,
-                pool.dynamicData?.lifetimeSwapFees ? `${pool.dynamicData.lifetimeSwapFees}` : `0`,
                 pool.dynamicData?.lifetimeVolume ? `${pool.dynamicData.lifetimeVolume}` : `0`,
-                pool.dynamicData?.volume24h ? `${pool.dynamicData.volume24h}` : `0`,
-                pool.dynamicData?.fees24h ? `${pool.dynamicData.fees24h}` : `0`,
-                sharesChange,
+                pool.dynamicData?.lifetimeSwapFees ? `${pool.dynamicData.lifetimeSwapFees}` : `0`,
                 tvlChange,
                 dailySwaps,
-                `1`,
+                sharesChange,
+                pool.dynamicData?.volume24h ? `${pool.dynamicData.volume24h}` : `0`,
+                pool.dynamicData?.fees24h ? `${pool.dynamicData.fees24h}` : `0`,
                 lpSwapFee,
                 protocolSwapFee,
                 blacklisted ? 'yes' : 'no',
                 this.chainSlug,
+                `1`,
             ]);
 
             const allTokens = pool.allTokens.map((token) => {
@@ -166,13 +169,14 @@ export class DatastudioService {
                 allPoolCompositionRows.push([
                     endOfYesterday.format('DD MMM YYYY'),
                     `${endOfYesterday.unix()}`,
+                    `${now}`,
+                    pool.address,
+                    pool.id,
+                    pool.name,
                     token.address,
                     token.name,
-                    pool.id,
-                    pool.address,
                     token.symbol,
                     token.weight ? token.weight : `0`,
-                    pool.name,
                     `${token.balance}`,
                 ]);
             }
@@ -189,6 +193,7 @@ export class DatastudioService {
                         allEmissionDataRows.push([
                             endOfYesterday.format('DD MMM YYYY'),
                             `${endOfYesterday.unix()}`,
+                            `${now}`,
                             pool.address,
                             pool.name,
                             'BEETS',
@@ -210,6 +215,7 @@ export class DatastudioService {
                                 allEmissionDataRows.push([
                                     endOfYesterday.format('DD MMM YYYY'),
                                     `${endOfYesterday.unix()}`,
+                                    `${now}`,
                                     pool.address,
                                     pool.name,
                                     rewardToken.symbol,
@@ -234,6 +240,7 @@ export class DatastudioService {
                             allEmissionDataRows.push([
                                 endOfYesterday.format('DD MMM YYYY'),
                                 `${endOfYesterday.unix()}`,
+                                `${now}`,
                                 pool.address,
                                 pool.name,
                                 rewardToken.symbol,
@@ -249,15 +256,15 @@ export class DatastudioService {
 
         console.log(`Appending ${allPoolDataRows.length} rows to ${this.databaseTabName}.`);
 
-        this.appendDataInSheet(this.databaseTabName, 'A1:V1', allPoolDataRows, jwtClient);
+        this.appendDataInSheet(this.databaseTabName, 'A1:W1', allPoolDataRows, jwtClient);
 
         console.log(`Appending ${allPoolCompositionRows.length} rows to ${this.compositionTabName}.`);
 
-        this.appendDataInSheet(this.compositionTabName, `A1:J1`, allPoolCompositionRows, jwtClient);
+        this.appendDataInSheet(this.compositionTabName, `A1:K1`, allPoolCompositionRows, jwtClient);
 
         console.log(`Appending ${allEmissionDataRows.length} rows to ${this.emissionDataTabName}.`);
 
-        this.appendDataInSheet(this.emissionDataTabName, 'A1:H1', allEmissionDataRows, jwtClient);
+        this.appendDataInSheet(this.emissionDataTabName, 'A1:I1', allEmissionDataRows, jwtClient);
     }
 
     private async updateDataInSheet(tabName: string, rowRange: string, rows: string[][], jwtClient: JWT) {

--- a/modules/pool/lib/apr-data-sources/optimism/wsteth-apr.service.ts
+++ b/modules/pool/lib/apr-data-sources/optimism/wsteth-apr.service.ts
@@ -24,8 +24,10 @@ export class WstethAprService implements PoolAprService {
             const wstethTokenBalance = wstethToken?.dynamicData?.balance;
             if (wstethTokenBalance && pool.dynamicData) {
                 if (!wstethBaseApr) {
-                    const { data } = await axios.get<string>(this.wstethAprEndpoint);
-                    wstethBaseApr = parseFloat(data) / 100;
+                    const { data } = await axios.get<{
+                        data: { aprs: [{ timeUnix: number; apr: number }]; smaApr: number };
+                    }>(this.wstethAprEndpoint);
+                    wstethBaseApr = data.data.smaApr / 100;
                 }
                 const wstethPercentage =
                     (parseFloat(wstethTokenBalance) * wstethPrice) / pool.dynamicData.totalLiquidity;

--- a/modules/pool/lib/pool-utils.ts
+++ b/modules/pool/lib/pool-utils.ts
@@ -11,13 +11,19 @@ export function isStablePool(poolType: PrismaPoolType) {
     return poolType === 'STABLE' || poolType === 'META_STABLE' || poolType === 'PHANTOM_STABLE';
 }
 
-export function isWeightedPoolV2(pool: PoolWithTypeAndFactory): boolean {
-    return pool.type === 'WEIGHTED' && isSameAddress(pool.factory || '', networkConfig.balancer.weightedPoolV2Factory);
+export function isWeightedPoolV2(pool: PoolWithTypeAndFactory) {
+    return (
+        pool.type === 'WEIGHTED' &&
+        networkConfig.balancer.weightedPoolV2Factories.find((factory) => isSameAddress(pool.factory || '', factory)) !==
+            undefined
+    );
 }
 
 export function isComposableStablePool(pool: PoolWithTypeAndFactory) {
     return (
         pool.type === 'PHANTOM_STABLE' &&
-        isSameAddress(pool.factory || '', networkConfig.balancer.coposableStablePoolFactory)
+        networkConfig.balancer.composableStablePoolFactories.find((factory) =>
+            isSameAddress(pool.factory || '', factory),
+        ) !== undefined
     );
 }

--- a/modules/pool/pool.gql
+++ b/modules/pool/pool.gql
@@ -662,7 +662,7 @@ type GqlPoolJoinExit {
     sender: String!
     poolId: String!
     timestamp: Int!
-    valueUSD: String!
+    valueUSD: String
     tx: String!
     amounts: [GqlPoolJoinExitAmount!]!
 }

--- a/modules/pool/pool.service.ts
+++ b/modules/pool/pool.service.ts
@@ -295,7 +295,6 @@ export const poolService = new PoolService(
                   new SpookySwapAprService(tokenService),
                   new YearnVaultAprService(tokenService),
                   new StaderStakedFtmAprService(tokenService),
-                  new ReaperCryptAprService(networkConfig.reaper!.linearPoolFactories, tokenService),
               ]
             : [
                   new RocketPoolStakedEthAprService(tokenService, networkConfig.balancer.yieldProtocolFeePercentage),
@@ -305,9 +304,13 @@ export const poolService = new PoolService(
                       networkConfig.lido!.wstEthContract,
                       networkConfig.balancer.yieldProtocolFeePercentage,
                   ),
-                  new ReaperCryptAprService(networkConfig.reaper!.linearPoolFactories, tokenService),
                   new OvernightAprService(networkConfig.overnight!.aprEndpoint, tokenService),
               ]),
+        new ReaperCryptAprService(
+            networkConfig.reaper.linearPoolFactories,
+            networkConfig.reaper.averageAPRAcrossLastNHarvests,
+            tokenService,
+        ),
         new PhantomStableAprService(networkConfig.balancer.yieldProtocolFeePercentage),
         new BoostedPoolAprService(networkConfig.balancer.yieldProtocolFeePercentage),
         new SwapFeeAprService(networkConfig.balancer.swapProtocolFeePercentage),


### PR DESCRIPTION
- averageAPRAcrossLastNHarvests is now configurable (2 for OP, 5 for FTM)
- wstETH uses new API as APR source
- Added fields to datafeed
- Changed to v2 subgraphs (new code, new factories)
- Fixed the empty array error in the block subgraph query