### PR TITLE
Make docker-compose launch all services and a setup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16-slim
+
+WORKDIR /app
+
+RUN apt-get update -y && apt-get install -y openssl
+
+CMD ["yarn","start:local"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ There are 2 kinds of graphql types to generate. We have types for interacting wi
 for our exposed graphql api schema.
 Run `yarn generate` to generate all gql types
 
+
+## Running with docker
+
+```
+docker compose up -d 
+```
+
+Viewing logs:
+```
+docker compose logs -f
+```
+
+## Running Manually
+
 ### Setup database & Prisma
 
 #### Start docker container (or manually set up your database)
@@ -42,6 +56,28 @@ poolSyncAllPoolsFromSubgraph
 poolReloadStakingForAllPools
 userInitWalletBalancesForAllPools
 userInitStakedBalances
+```
+
+You can do this by sending the following GraphQL command to the server:
+
+```
+mutation init {
+  poolSyncAllPoolsFromSubgraph
+  poolReloadStakingForAllPools(stakingTypes: [MASTER_CHEF, GAUGE, RELIQUARY, FRESH_BEETS])
+  userInitWalletBalancesForAllPools
+  userInitStakedBalances(stakingTypes: [MASTER_CHEF, GAUGE, RELIQUARY, FRESH_BEETS])
+}
+```
+
+With the following HTTP headers:
+```
+{"AdminApiKey": "key-you-set-in-env-file"}
+```
+
+### Start a local server
+
+```
+yarn start:local
 ```
 
 ## Branching and deployment environments

--- a/app.ts
+++ b/app.ts
@@ -13,7 +13,6 @@ import {
 } from 'apollo-server-core';
 import { schema } from './graphql_schema_generated';
 import { resolvers } from './app/gql/resolvers';
-import { scheduleLocalWorkerTasks } from './worker/scheduleLocalWorkerTasks';
 import helmet from 'helmet';
 import GraphQLJSON from 'graphql-type-json';
 import * as Sentry from '@sentry/node';
@@ -111,14 +110,6 @@ async function startServer() {
 
     await new Promise<void>((resolve) => httpServer.listen({ port: env.PORT }, resolve));
     console.log(`🚀 Server ready at http://localhost:${env.PORT}${server.graphqlPath}`);
-
-    if (process.env.NODE_ENV === 'local' && process.env.CRONS === 'true') {
-        try {
-            scheduleLocalWorkerTasks();
-        } catch (e) {
-            console.log(`Fatal error happened during cron scheduling.`, e);
-        }
-    }
 }
 
 if (process.env.WORKER === 'true') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,56 @@ services:
         ports:
             - '5431:5432'
         environment:
-            POSTGRES_USER: beetx
-            POSTGRES_PASSWORD: let-me-in
-            POSTGRES_DB: beetx
+            POSTGRES_USER: ${POSTGRES_USER}
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+            POSTGRES_DB: ${POSTGRES_DB}
+        volumes:
+            - postgres:/var/lib/postgresql/data
+    app:
+        restart: on-failure
+        build: ./
+        hostname: app
+        ports:
+            - '4000:4000'
+        env_file:
+            - ./.env
+        environment:
+            - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?schema=public
+        volumes:
+            - ./:/app
+        depends_on:
+            - postgres
+    worker:
+        restart: on-failure
+        build: ./
+        hostname: worker
+        ports:
+            - '5000:4000'
+        env_file:
+            - ./.env
+        environment:
+            - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?schema=public
+            - WORKER=true
+            - CRONS=true
+        volumes:
+            - ./:/app
+        depends_on:
+            - postgres
+            - app
+    setup:
+        restart: 'no'
+        build: ./
+        hostname: setup
+        volumes:
+            - ./:/app
+        env_file:
+            - ./.env
+        environment:
+            - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?schema=public
+        entrypoint: ["/bin/sh", "-c" , "yarn generate && yarn prisma migrate dev"]
+        depends_on:
+            - postgres
+            - app
+
+volumes:
+    postgres:

--- a/env.local
+++ b/env.local
@@ -2,8 +2,12 @@ PORT=4000
 NODE_ENV=local
 DEPLOYMENT_ENV=canary
 
+POSTGRES_USER=beetx
+POSTGRES_PASSWORD=let-me-in
+POSTGRES_DB=beetx
+
 # Database
-DATABASE_URL=postgresql://beetx:let-me-in@localhost:5431/beetx?schema=public
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5431/${POSTGRES_DB}?schema=public
 
 # AWS only
 AWS_REGION=ca-central-1

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -6,6 +6,7 @@ import { prisma } from '../prisma/prisma-client';
 import { configureWorkerRoutes } from './job-handlers';
 import { createAlerts, scheduleJobs as scheduleJobs } from './manual-jobs';
 import { networkConfig } from '../modules/config/network-config';
+import { scheduleLocalWorkerTasks } from './scheduleLocalWorkerTasks';
 
 export function startWorker() {
     const app = express();
@@ -35,6 +36,14 @@ export function startWorker() {
             },
         }),
     );
+
+    if (process.env.NODE_ENV === 'local' && process.env.CRONS === 'true') {
+        try {
+            scheduleLocalWorkerTasks();
+        } catch (e) {
+            console.log(`Fatal error happened during cron scheduling.`, e);
+        }
+    }
 
     if (env.NODE_ENV !== 'local') {
         scheduleJobs();


### PR DESCRIPTION
Wanted to make it easy for anyone to spin this up locally with one command. 

- Extend docker-compose file to run the app, worker and setup script. 
- Move `scheduleWorkerTasks` to the worker file.
- Make worker run cron tasks on launch.
- Improve README, describing how to run the mutations and start the server. 
