### PR TITLE
Update token list to be same as Balancer frontend

### DIFF
--- a/modules/content/github-content.service.ts
+++ b/modules/content/github-content.service.ts
@@ -5,7 +5,7 @@ import { prisma } from '../../prisma/prisma-client';
 import { networkContext } from '../network/network-context.service';
 import { ContentService, HomeScreenFeaturedPoolGroup, HomeScreenNewsItem } from './content-types';
 
-const TOKEN_LIST_URL = 'https://raw.githubusercontent.com/balancer/tokenlists/main/generated/balancer.tokenlist.json';
+const TOKEN_LIST_URL = 'https://raw.githubusercontent.com/balancer/tokenlists/main/generated/listed-old.tokenlist.json';
 
 interface WhitelistedTokenList {
     name: string;


### PR DESCRIPTION
Updating the tokens list for whitelisted tokens so that the Balancer Frontend can fetch prices from the API and have the same price list as it currently does. 

The Balancer frontend fetches prices for tokens on the `Default` token list, which is this URL. The old URL was the `vetted` list which is used for checking if pools have unknown tokens but isn't used for price fetching.

Old URL (all known tokens): https://github.com/balancer/frontend-v2/blob/develop/src/lib/config/mainnet/tokenlists.ts#L8
New URL (all tokens the frontend fetches prices for): https://github.com/balancer/frontend-v2/blob/develop/src/lib/config/mainnet/tokenlists.ts#L6