### PR TITLE
Fix bugs in Github Token Fetching

### DIFF
--- a/modules/content/github-content.service.ts
+++ b/modules/content/github-content.service.ts
@@ -28,7 +28,14 @@ export class GithubContentService implements ContentService {
         const { data: githubAllTokenList } = await axios.get<WhitelistedTokenList>(TOKEN_LIST_URL);
 
         const filteredTokenList = githubAllTokenList.tokens.filter(
-            (token) => `${token.chainId}` === networkContext.chainId,
+            (token) =>  {
+                if (`${token.chainId}` !== networkContext.chainId) {
+                    return false;
+                }
+
+                const requiredKeys = ['chainId', 'address', 'name', 'symbol', 'decimals']
+                return requiredKeys.every((key) => token?.[key as keyof WhitelistedToken] != null)
+            }
         );
 
         for (const githubToken of filteredTokenList) {
@@ -135,7 +142,7 @@ export class GithubContentService implements ContentService {
             }
 
             const linearPool = pools.find(
-                (pool) => pool.linearData && pool.tokens[pool.linearData.wrappedIndex].address === token.address,
+                (pool) => pool.linearData && pool.tokens[pool.linearData.wrappedIndex]?.address === token.address,
             );
 
             if (linearPool && !tokenTypes.includes('LINEAR_WRAPPED_TOKEN')) {

--- a/worker/job-handlers.ts
+++ b/worker/job-handlers.ts
@@ -69,7 +69,7 @@ async function runIfNotAlreadyRunning(id: string, chainId: string, fn: () => any
             scope.setTag('error', jobId);
         });
 
-        console.log(`Error job ${jobId}`);
+        console.log(`Error job ${jobId}`, error);
     } finally {
         runningJobs.delete(jobId);
         console.timeEnd(jobId);


### PR DESCRIPTION
- Ignore tokens that are missing required keys. The tokenlist had a few invalid tokens which caused this job to fail, this is fixed in https://github.com/balancer/tokenlists/pull/38 but also fixing it here just in case.
- Fix error when a linear pool tokens list doesn't have a token in the wrappedIndex slot. This happens when a pool is missing a tokens list, as many pools currently are.
- When an error occurs in a job, log that error so we can debug failing jobs easier. 