### PR TITLE
Fix missing prices causing an error

### DIFF
--- a/modules/token/lib/token-price-handlers/swaps-price-handler.service.ts
+++ b/modules/token/lib/token-price-handlers/swaps-price-handler.service.ts
@@ -27,7 +27,7 @@ export class SwapsPriceHandlerService implements TokenPriceHandler {
                     !token.types.includes('BPT') &&
                     !token.types.includes('PHANTOM_BPT') &&
                     !token.types.includes('LINEAR_WRAPPED_TOKEN') &&
-                    (!token.coingeckoPlatformId || token.prices[0].timestamp < threeHoursAgo),
+                    (!token.coingeckoPlatformId || !token.prices.length || token.prices[0].timestamp < threeHoursAgo),
             )
             .map((token) => token.address);
     }


### PR DESCRIPTION
- If a token has no existing price data this getAcceptedToken crashes becuase it can't read the timestamp of the first price. Adding this check ensures it will accept any tokens that have no prices.