### PR TITLE
Fix metrics import

### DIFF
--- a/modules/protocol/protocol.resolvers.ts
+++ b/modules/protocol/protocol.resolvers.ts
@@ -1,13 +1,13 @@
-import { GqlLatestSyncedBlocks, GqlProtocolMetrics, Resolvers } from '../../schema';
+import { GqlLatestSyncedBlocks, GqlProtocolMetricsAggregated, GqlProtocolMetricsChain, Resolvers } from '../../schema';
 import { protocolService } from './protocol.service';
 import { networkContext } from '../network/network-context.service';
 
 const protocolResolvers: Resolvers = {
     Query: {
-        protocolMetrics: async (): Promise<GqlProtocolMetrics> => {
+        protocolMetrics: async (): Promise<GqlProtocolMetricsAggregated> => {
             return protocolService.getGlobalMetrics();
         },
-        chainMetrics: async (): Promise<GqlProtocolMetrics> => {
+        chainMetrics: async (): Promise<GqlProtocolMetricsChain> => {
             return protocolService.getMetrics(networkContext.chainId);
         },
         latestSyncedBlocks: async (): Promise<GqlLatestSyncedBlocks> => {


### PR DESCRIPTION
Fixing up the types of imports. The type was changed in https://github.com/beethovenxfi/beethovenx-backend/commit/aacf4a80e995493e61d0ee5ec9a864acea3f0d41 but this file wasn't updated. 