### PR TITLE
Set mainnet ETH address to 0xeee

### DIFF
--- a/modules/network/arbitrum.ts
+++ b/modules/network/arbitrum.ts
@@ -22,7 +22,7 @@ const arbitrumNetworkData: NetworkData = {
     chain: {
         slug: 'arbitrum',
         id: 42161,
-        nativeAssetAddress: '0xb5AE3c648709913Ef9739e9F6eDB5a821c6Ab160',
+        nativeAssetAddress: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
         wrappedNativeAssetAddress: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
         prismaId: 'ARBITRUM',
         gqlId: 'ARBITRUM',
@@ -36,8 +36,8 @@ const arbitrumNetworkData: NetworkData = {
         userBalances: 'https://',
     },
     eth: {
-        address: '0xb5ae3c648709913ef9739e9f6edb5a821c6ab160',
-        addressFormatted: '0xb5AE3c648709913Ef9739e9F6eDB5a821c6Ab160',
+        address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        addressFormatted: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
         symbol: 'ETH',
         name: 'Ether',
     },

--- a/modules/network/mainnet.ts
+++ b/modules/network/mainnet.ts
@@ -36,8 +36,8 @@ const mainnetNetworkData: NetworkData = {
         userBalances: 'https://',
     },
     eth: {
-        address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-        addressFormatted: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        addressFormatted: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
         symbol: 'ETH',
         name: 'Ether',
     },

--- a/modules/network/mainnet.ts
+++ b/modules/network/mainnet.ts
@@ -22,7 +22,7 @@ const mainnetNetworkData: NetworkData = {
     chain: {
         slug: 'ethereum',
         id: 1,
-        nativeAssetAddress: '0xb5AE3c648709913Ef9739e9F6eDB5a821c6Ab160',
+        nativeAssetAddress: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
         wrappedNativeAssetAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
         prismaId: 'MAINNET',
         gqlId: 'MAINNET',
@@ -36,8 +36,8 @@ const mainnetNetworkData: NetworkData = {
         userBalances: 'https://',
     },
     eth: {
-        address: '0xb5ae3c648709913ef9739e9f6edb5a821c6ab160',
-        addressFormatted: '0xb5AE3c648709913Ef9739e9F6eDB5a821c6Ab160',
+        address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+        addressFormatted: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
         symbol: 'ETH',
         name: 'Ether',
     },

--- a/prisma/migrations/20230426080508_add_gnosis_chain/migration.sql
+++ b/prisma/migrations/20230426080508_add_gnosis_chain/migration.sql
@@ -1,2 +1,0 @@
--- AlterEnum
-ALTER TYPE "Chain" ADD VALUE 'GNOSIS';


### PR DESCRIPTION
The native asset address of Ethereum and Arbitrum were wrong. Setting these addresses to 0xeee so the price of the native token is in the token prices list for the Balancer frontend. 