### PR TITLE
Default to swapEnabled=false when onchain sync fails.

### DIFF
--- a/modules/pool/lib/pool-on-chain-data.service.ts
+++ b/modules/pool/lib/pool-on-chain-data.service.ts
@@ -324,10 +324,13 @@ export class PoolOnChainDataService {
                 const swapFee = formatFixed(poolData.swapFee, 18);
                 const totalShares = formatFixed(poolData.totalSupply, 18);
                 let swapEnabled: boolean | undefined;
-                if (typeof multicallResult?.swapEnabled !== 'undefined') swapEnabled = multicallResult.swapEnabled;
-                else if (typeof multicallResult?.pausedState !== 'undefined')
+                if (typeof multicallResult?.swapEnabled !== 'undefined') {
+                    swapEnabled = multicallResult.swapEnabled;
+                } else if (typeof multicallResult?.pausedState !== 'undefined') {
                     swapEnabled = !multicallResult.pausedState[0];
-                else swapEnabled = pool.dynamicData?.swapEnabled;
+                } else {
+                    swapEnabled = pool.dynamicData?.swapEnabled;
+                }
 
                 if (
                     pool.dynamicData &&


### PR DESCRIPTION
There is an issue with swapEnabled state for some pools, for example: 
Mainnet: `0x3c640f0d3036ad85afa2d5a9e32be651657b874f00000000000000000000046b` is broken EulerLinear pool. It was previously ok so swapEnabled was set to true. 
Now when onchain state is trying to be sync'd the multicall throws an error and the pool sync gets skipped. 
This causes issues on b-sdk as the pool continues to show swapEnable=true so gets considered as a possible swap pool.

Not sure if what the effects are of setting other pools that throw during the multicall request but would assume if there's an issue with that then there is likely an issue with the pool. Alternative would be to add known broken pools to the ignore list so they don't get considered by b-sdk but this seems hard to maintain.