### PR TITLE
Update onchain data service

### DIFF
--- a/modules/pool/lib/pool-on-chain-data.service.ts
+++ b/modules/pool/lib/pool-on-chain-data.service.ts
@@ -9,7 +9,7 @@ import { formatFixed } from '@ethersproject/bignumber';
 import { PrismaPoolType } from '@prisma/client';
 import { isSameAddress } from '@balancer-labs/sdk';
 import { prisma } from '../../../prisma/prisma-client';
-import { isComposableStablePool, isStablePool, isWeightedPoolV2 } from './pool-utils';
+import { isComposableStablePool, isGyroEV2, isStablePool, isWeightedPoolV2 } from './pool-utils';
 import { TokenService } from '../../token/token.service';
 import BalancerPoolDataQueryAbi from '../abi/BalancerPoolDataQueries.json';
 import { networkContext } from '../../network/network-context.service';
@@ -182,7 +182,7 @@ export class PoolOnChainDataService {
             if (pool.type === 'LINEAR' || isComposableStablePool(pool) || pool.type.includes('GYRO')) {
                 ratePoolIdexes.push(poolIdsFromDb.findIndex((orderedPoolId) => orderedPoolId === pool.id));
             }
-            if (pool.type === 'LINEAR' || isComposableStablePool(pool) || pool.type === 'META_STABLE') {
+            if (pool.type === 'LINEAR' || isComposableStablePool(pool) || pool.type === 'META_STABLE' || isGyroEV2(pool)) {
                 scalingFactorPoolIndexes.push(poolIdsFromDb.findIndex((orderedPoolId) => orderedPoolId === pool.id));
             }
         }

--- a/modules/pool/lib/pool-on-chain-data.service.ts
+++ b/modules/pool/lib/pool-on-chain-data.service.ts
@@ -169,7 +169,6 @@ export class PoolOnChainDataService {
         const stablePoolIdexes: number[] = [];
         const ratePoolIdexes: number[] = [];
         const scalingFactorPoolIndexes: number[] = [];
-        const gyroPoolIdexes: number[] = [];
         for (const pool of filteredPools) {
             if (pool.type === 'WEIGHTED' || pool.type === 'LIQUIDITY_BOOTSTRAPPING' || pool.type === 'INVESTMENT') {
                 weightedPoolIndexes.push(poolIdsFromDb.findIndex((orderedPoolId) => orderedPoolId === pool.id));
@@ -187,8 +186,6 @@ export class PoolOnChainDataService {
                 scalingFactorPoolIndexes.push(poolIdsFromDb.findIndex((orderedPoolId) => orderedPoolId === pool.id));
             }
         }
-
-        const ratePoolsIndexes = [...linearPoolIdexes, ...gyroPoolIdexes];
 
         const queryPoolDataResult = await this.queryPoolData({
             poolIds: poolIdsFromDb,
@@ -227,8 +224,8 @@ export class PoolOnChainDataService {
                 weightedPoolIdxs: weightedPoolIndexes,
                 loadLinearWrappedTokenRates: linearPoolIdexes.length > 0,
                 linearPoolIdxs: linearPoolIdexes,
-                loadRates: ratePoolsIndexes.length > 0,
-                ratePoolIdxs: ratePoolsIndexes,
+                loadRates: ratePoolIdexes.length > 0,
+                ratePoolIdxs: ratePoolIdexes,
                 loadScalingFactors: scalingFactorPoolIndexes.length > 0,
                 scalingFactorPoolIdxs: scalingFactorPoolIndexes,
             },

--- a/modules/pool/lib/pool-utils.ts
+++ b/modules/pool/lib/pool-utils.ts
@@ -8,6 +8,7 @@ type PoolWithTypeAndFactory = {
     type: PrismaPoolType;
     factory?: string | null;
     dynamicData?: PrismaPoolDynamicData | null;
+    version: number;
 };
 
 export function isStablePool(poolType: PrismaPoolType) {
@@ -41,4 +42,8 @@ export function collectsYieldFee(pool: PoolWithTypeAndFactory) {
 
 export function capturesYield(pool: PoolWithTypeAndFactory) {
     return isWeightedPoolV2(pool) || isComposableStablePool(pool) || pool.type === 'META_STABLE';
+}
+
+export function isGyroEV2(pool: PoolWithTypeAndFactory) {
+    return pool.type === 'GYROE' && pool.version === 2;
 }


### PR DESCRIPTION
* Looked like ratePoolIdxs was only using Linear pool ids but should have been using ratePoolIdexes?
* Added GyroE V2 to scalingFactorPoolIndexes as they need to have updated token rates

Tested using `poolLoadOnChainDataForAllPools` mutation on Polygon network as it has GyroE V2. Seemed to run ok.