### PR TITLE
Add schedule and reschedule logs to trace source of cron failure error

### DIFF
--- a/worker/job-handlers.ts
+++ b/worker/job-handlers.ts
@@ -109,11 +109,13 @@ async function runIfNotAlreadyRunning(id: string, chainId: string, fn: () => any
 
 export async function scheduleWithInterval(job: WorkerJob, chainId: string): Promise<void> {
     try {
+        console.log(`Schedule job ${job.name}-${chainId}`)
         await scheduleJob(job, chainId);
     } catch (error) {
         console.log(error);
         Sentry.captureException(error);
     } finally {
+        console.log(`Reschedule job ${job.name}-${chainId}`)
         setTimeout(() => {
             scheduleWithInterval(job, chainId);
         }, job.interval);


### PR DESCRIPTION
Adding logs for when a job is scheduled and when it's re-scheduled to determine what is happening when a cron stops running. If a function call like `AsyncLocalStorage` or a sentry function is hanging this should give us a better idea where it's happening. 