### PR TITLE
hotfix: Return syncVotingGauges promise

### DIFF
--- a/modules/vebal/vebal-voting-list.service.ts
+++ b/modules/vebal/vebal-voting-list.service.ts
@@ -117,7 +117,7 @@ export class VeBalVotingListService {
     async syncVotingGauges() {
         const onchainGaugeAddresses = await this.votingGauges.getVotingGaugeAddresses();
 
-        this.sync(onchainGaugeAddresses);
+        return this.sync(onchainGaugeAddresses);
     }
 
     async sync(votingGaugeAddresses: string[]) {


### PR DESCRIPTION
`syncVortingGauges` was not returning so when calling it from the [jobHandler](https://github.com/beethovenxfi/beethovenx-backend/blob/fix/return-syncVotingGauges-promise/worker/job-handlers.ts#L67) was not awaiting for the sync to be completed. 

Now it returns so the promise can be awaited 

