### PR TITLE
fix: allow duplicated pools

### DIFF
--- a/modules/vebal/special-pools/ve-pools.ts
+++ b/modules/vebal/special-pools/ve-pools.ts
@@ -11,21 +11,29 @@ export const veGauges = Object.values(vePools).map((v) => v.toLowerCase());
 
 const isVebalPool = (poolId: string) => poolId === '0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014';
 
-export function getVeVotingGauge(poolId: string) {
+export function getVeVotingGauges() {
     // Make sure that gauge addresses and poolIds are lowercase
     const vePoolsLowerCase: Record<string, string> = {};
     Object.entries(vePools).forEach(([key, value]) => {
         vePoolsLowerCase[key.toLowerCase()] = value.toLowerCase();
     });
 
-    const veVotingGaugeAddress = vePoolsLowerCase[poolId];
-    if (!veVotingGaugeAddress) return;
-    return {
-        // veBal pool have a max of 10% voting weight (AKA '0.1' relativeWeightCap)
-        relativeWeightCap: isVebalPool(poolId) ? '0.1' : null,
-        id: veVotingGaugeAddress,
-        status: 'ACTIVE' as const,
-        addedTimestamp: null,
-        stakingGauge: null,
-    };
+    let veVotingGauges = [];
+    for (const poolId in vePoolsLowerCase) {
+        veVotingGauges.push({
+            // veBal pool have a max of 10% voting weight (AKA '0.1' relativeWeightCap)
+            relativeWeightCap: isVebalPool(poolId) ? '0.1' : null,
+            id: vePoolsLowerCase[poolId],
+            status: 'ACTIVE' as const,
+            addedTimestamp: null,
+            stakingGauge: {
+                staking: {
+                    poolId,
+                    address: vePoolsLowerCase[poolId],
+                },
+            },
+        });
+    }
+
+    return veVotingGauges;
 }


### PR DESCRIPTION
In `getVotingList`,  we were iterating the list of different pools but it can be that the same pool should appear twice: 

1. Pool with new gauge
2. Same pool with old killed but still active gauge

That's why in this fix we build the list iterating the voting gauges instead of the pools.  