### PR TITLE
Allow specifying networks for scheduler and scheduling using localhost

### DIFF
--- a/app/env.ts
+++ b/app/env.ts
@@ -26,6 +26,10 @@ export const schema = {
         optional: true,
         type: String,
     },
+    SUPPORTED_NETWORKS: {
+        optional: true,
+        type: String,
+    },
     WORKER_QUEUE_URL: String,
 };
 

--- a/worker/job-queue.ts
+++ b/worker/job-queue.ts
@@ -10,9 +10,10 @@ class WokerQueue {
     public async sendWithInterval(json: string, intervalMs: number, deDuplicationId?: string): Promise<void> {
         try {
             if (env.WORKER_QUEUE_URL.match(/localhost/)) {
-                return this.sendLocalMessage(json );
+                await this.sendLocalMessage(json );
+            } else {
+                await this.sendMessage(json, deDuplicationId);
             }
-            await this.sendMessage(json, deDuplicationId);
             console.log(`Sent message to schedule job on queue ${env.WORKER_QUEUE_URL}: ${json}`);
         } catch (error) {
             console.log(error);

--- a/worker/scheduler.ts
+++ b/worker/scheduler.ts
@@ -15,7 +15,8 @@ export async function startScheduler() {
     });
 
     try {
-        for (const chainId of Object.keys(AllNetworkConfigs)) {
+        const chainIds = env.SUPPORTED_NETWORKS ? env.SUPPORTED_NETWORKS.split(',') : Object.keys(AllNetworkConfigs);
+        for (const chainId of chainIds) {
             scheduleJobs(chainId);
             if (process.env.AWS_ALERTS === 'true') {
                 //start up time will be a bit slower


### PR DESCRIPTION
- Adds ability to set the WORKER_QUEUE_URL to something running on localhost, the scheduler will then post jobs to that endpoint instead of the queue, for local development. 
- re-add SUPPORTED_NETWORKS env variable  which makes the scheduler only post jobs for those chains instead of all chains.  