### PR TITLE
fix: Delete votingGauge entry before deleting a staking gauge.

### DIFF
--- a/modules/pool/pool.service.ts
+++ b/modules/pool/pool.service.ts
@@ -466,6 +466,22 @@ export class PoolService {
                         where: { chain: networkContext.chain, gaugeId: staking.id },
                     });
 
+                    // delete votingGauge entry before deleting the staking gauge
+                    let gauge = await prisma.prismaPoolStakingGauge.findFirst({
+                        where: {
+                            chain: networkContext.chain,
+                            stakingId: staking.id,
+                        },
+                        select: {
+                            votingGauge: true,
+                        },
+                    });
+
+                    if(gauge && gauge.votingGauge)
+                        await prisma.prismaVotingGauge.deleteMany({
+                            where: { chain: networkContext.chain, id: gauge.votingGauge.id }
+                        });
+
                     await prisma.prismaPoolStakingGauge.deleteMany({
                         where: { chain: networkContext.chain, stakingId: staking.id },
                     });


### PR DESCRIPTION
Can test by deleting pool `0xf0ad209e2e969eaaa8c882aac71f02d8a047d5c2000200000000000000000b49` on Polygon. Currently throws an error but doesn't after this change.