### PR TITLE
fix: scientific notation for dust

### DIFF
--- a/modules/pool/lib/pool-gql-loader.service.ts
+++ b/modules/pool/lib/pool-gql-loader.service.ts
@@ -37,6 +37,7 @@ import { Prisma, PrismaPoolAprType } from '@prisma/client';
 import { isWeightedPoolV2 } from './pool-utils';
 import { oldBnum } from '../../big-number/old-big-number';
 import { networkContext } from '../../network/network-context.service';
+import { fixedNumber } from '../../view-helpers/fixed-number';
 
 export class PoolGqlLoaderService {
     public async getPool(id: string): Promise<GqlPoolUnion> {
@@ -660,27 +661,27 @@ export class PoolGqlLoaderService {
 
         return {
             ...pool.dynamicData!,
-            totalLiquidity: `${totalLiquidity}`,
-            totalLiquidity24hAgo: `${totalLiquidity24hAgo}`,
+            totalLiquidity: `${fixedNumber(totalLiquidity, 2)}`,
+            totalLiquidity24hAgo: `${fixedNumber(totalLiquidity24hAgo, 2)}`,
             totalShares24hAgo,
-            fees24h: `${fees24h}`,
-            volume24h: `${volume24h}`,
-            yieldCapture24h: `${yieldCapture24h}`,
-            yieldCapture48h: `${yieldCapture48h}`,
-            fees48h: `${fees48h}`,
-            volume48h: `${volume48h}`,
-            lifetimeVolume: `${lifetimeVolume}`,
-            lifetimeSwapFees: `${lifetimeSwapFees}`,
+            fees24h: `${fixedNumber(fees24h, 2)}`,
+            volume24h: `${fixedNumber(volume24h, 2)}`,
+            yieldCapture24h: `${fixedNumber(yieldCapture24h, 2)}`,
+            yieldCapture48h: `${fixedNumber(yieldCapture48h, 2)}`,
+            fees48h: `${fixedNumber(fees48h, 2)}`,
+            volume48h: `${fixedNumber(volume48h, 2)}`,
+            lifetimeVolume: `${fixedNumber(lifetimeVolume, 2)}`,
+            lifetimeSwapFees: `${fixedNumber(lifetimeSwapFees, 2)}`,
             holdersCount: `${holdersCount}`,
             swapsCount: `${swapsCount}`,
             sharePriceAth: `${sharePriceAth}`,
             sharePriceAtl: `${sharePriceAtl}`,
-            totalLiquidityAth: `${totalLiquidityAth}`,
-            totalLiquidityAtl: `${totalLiquidityAtl}`,
-            volume24hAtl: `${volume24hAtl}`,
-            volume24hAth: `${volume24hAth}`,
-            fees24hAtl: `${fees24hAtl}`,
-            fees24hAth: `${fees24hAth}`,
+            totalLiquidityAth: `${fixedNumber(totalLiquidityAth, 2)}`,
+            totalLiquidityAtl: `${fixedNumber(totalLiquidityAtl, 2)}`,
+            volume24hAtl: `${fixedNumber(volume24hAtl, 2)}`,
+            volume24hAth: `${fixedNumber(volume24hAth, 2)}`,
+            fees24hAtl: `${fixedNumber(fees24hAtl, 2)}`,
+            fees24hAth: `${fixedNumber(fees24hAth, 2)}`,
             sharePriceAthTimestamp,
             sharePriceAtlTimestamp,
             totalLiquidityAthTimestamp,

--- a/modules/view-helpers/fixed-number.ts
+++ b/modules/view-helpers/fixed-number.ts
@@ -1,0 +1,3 @@
+export const fixedNumber = (value: number, precision: number) => {
+    return value.toFixed(precision);
+}


### PR DESCRIPTION
small USD amounts were returned in scientific notation, rounding to 2 should be enough