### PR TITLE
dust pools BPT price

### DIFF
--- a/modules/token/lib/token-price-handlers/bpt-price-handler.service.ts
+++ b/modules/token/lib/token-price-handlers/bpt-price-handler.service.ts
@@ -31,7 +31,12 @@ export class BptPriceHandlerService implements TokenPriceHandler {
                 pool.dynamicData.totalLiquidity !== 0 &&
                 parseFloat(pool.dynamicData.totalShares) !== 0
             ) {
-                const price = pool.dynamicData.totalLiquidity / parseFloat(pool.dynamicData.totalShares);
+                let price = pool.dynamicData.totalLiquidity / parseFloat(pool.dynamicData.totalShares);
+
+                // Handle 'dust' pools with very low liquidity
+                if (parseFloat(pool.dynamicData.totalShares) < 1) {
+                    price = 0
+                }
 
                 updated.push(token.address);
 


### PR DESCRIPTION
Some BPT prices are getting miscalculated because of very low liquidity. We can assume liquidity = 0 when there is < 1 share of the pool.