### PR TITLE
fix: use DB instead of slow subgraph

### DIFF
--- a/modules/user/lib/user-sync-gauge-balance.service.ts
+++ b/modules/user/lib/user-sync-gauge-balance.service.ts
@@ -117,7 +117,13 @@ export class UserSyncGaugeBalanceService implements UserStakedBalanceService {
         const latestBlock = await this.provider.getBlockNumber();
         console.log(`user-sync-staked-balances-${this.chainId} got latest block.`);
 
-        const gaugeAddresses = await gaugeSubgraphService.getAllGaugeAddresses();
+        // Get gauge addresses
+        const gaugeAddresses = (
+            await prisma.prismaPoolStakingGauge.findMany({
+                select: { gaugeAddress: true },
+                where: { chain: this.chain },
+            })
+        ).map((gauge) => gauge.gaugeAddress);
 
         // we sync at most 10k blocks at a time
         const startBlock = status.blockNumber + 1;


### PR DESCRIPTION
Replacing subgraph with DB for getting list of gauge addresses.