### PR TITLE
Update default fees for on-chain gyro

### DIFF
--- a/modules/pool/lib/pool-onchain-gyro-fee.ts
+++ b/modules/pool/lib/pool-onchain-gyro-fee.ts
@@ -70,9 +70,9 @@ export const fetchOnChainGyroFees = async (pools: PoolInput[], gyroConfigAddress
 
     const results = (await multicaller.execute()) as OnchainGyroFees;
     const defaultFee = results.defaultFee ?? '0';
-    const eclpFee = results.eclpFee ?? '0';
-    const twoClpFee = results.twoClpFee ?? '0';
-    const threeClpFee = results.threeClpFee ?? '0';
+    const eclpFee = results.eclpFee ?? defaultFee;
+    const twoClpFee = results.twoClpFee ?? defaultFee;
+    const threeClpFee = results.threeClpFee ?? defaultFee;
 
     let parsed: { [address: string]: string } = {};
     if (results.pools) {


### PR DESCRIPTION
This pull request updates the default fees for on-chain gyro calculations. Previously, if the fees for specific pool configurations were not available, a default fee of '0' was used. This PR changes the default fee to be the same as the default fee for other pool configurations. This ensures consistency in the fee calculations.